### PR TITLE
docs: fix simple typo, resovles -> resolves

### DIFF
--- a/doc/sphinx_ext/gen_rst.py
+++ b/doc/sphinx_ext/gen_rst.py
@@ -402,7 +402,7 @@ class NameFinder(ast.NodeVisitor):
 
 
 def identify_names(code):
-    """Builds a codeobj summary by identifying and resovles used names
+    """Builds a codeobj summary by identifying and resolves used names
 
     >>> code = '''
     ... from a.b import c


### PR DESCRIPTION
There is a small typo in doc/sphinx_ext/gen_rst.py.

Should read `resolves` rather than `resovles`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md